### PR TITLE
Reset PATH when configuring

### DIFF
--- a/ups/eupspkg.cfg.sh
+++ b/ups/eupspkg.cfg.sh
@@ -8,7 +8,7 @@ config()
     # in order that anaconda3 packages are not found 
     # (for example iconv)
     #
-    export PATH="/bin:/usr/bin/:/usr/local/bin"
+    export PATH="/bin:/usr/bin/:/usr/local/bin:$(dirname $(command -v $CC))"
     ./configure --prefix="$PREFIX" --with-apr="$APR_DIR"
 
 }

--- a/ups/eupspkg.cfg.sh
+++ b/ups/eupspkg.cfg.sh
@@ -1,3 +1,14 @@
 # EupsPkg config file. Sourced by 'eupspkg'
 
-CONFIGURE_OPTIONS="--prefix=$PREFIX --with-apr=$APR_DIR"
+config()
+{
+
+    #
+    # PATH reset during configuration
+    # in order that anaconda3 packages are not found 
+    # (for example iconv)
+    #
+    export PATH="/bin:/usr/bin/:/usr/local/bin"
+    ./configure --prefix="$PREFIX" --with-apr="$APR_DIR"
+
+}


### PR DESCRIPTION
This will avoid that when compiling apr_util, libraries from
local anaconda3 installation are used, for example iconv.
